### PR TITLE
3-8-1 모달창 개선

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
     ></script>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>
 </html>

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
@@ -19,7 +19,9 @@ export const ModalWrapper = forwardRef(
                 type="button"
                 className={styles['modal-exit-btn']}
                 onClick={onClick}
-              ></button>
+              >
+                <span className={styles['blind']}>질문 등록창 닫기</span>
+              </button>
             </div>
 
             <div className={styles['modal-receiver']}>

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import { QuestionForm } from '../QuestionForm/QuestionForm';
 import styles from './ModalWrapper.module.css';
+import { ReactComponent as Message } from '../../../assets/icon/ic-messages.svg';
 
 export const ModalWrapper = forwardRef(
   ({ onClick, onSubmit, onChange, placehorder, btnText }, ref) => {
@@ -12,16 +13,9 @@ export const ModalWrapper = forwardRef(
           <div className={styles['modal-wrapper']}>
             <div className={styles['modal-header']}>
               <div className={styles['modal-title']}>
-                <span className={styles['modal-icon']}></span>
+                <Message fill={'#000'} />
                 질문을 작성하세요
               </div>
-              <button
-                type="button"
-                className={styles['modal-exit-btn']}
-                onClick={onClick}
-              >
-                <span className={styles['blind']}>질문 등록창 닫기</span>
-              </button>
             </div>
 
             <div className={styles['modal-receiver']}>
@@ -36,6 +30,13 @@ export const ModalWrapper = forwardRef(
               placehorder={placehorder}
               btnText={btnText}
             />
+            <button
+              type="button"
+              className={styles['modal-exit-btn']}
+              onClick={onClick}
+            >
+              <span className={styles['blind']}>질문 등록창 닫기</span>
+            </button>
           </div>
         </div>
       </>

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.jsx
@@ -4,7 +4,7 @@ import styles from './ModalWrapper.module.css';
 import { ReactComponent as Message } from '../../../assets/icon/ic-messages.svg';
 
 export const ModalWrapper = forwardRef(
-  ({ onClick, onSubmit, onChange, placehorder, btnText }, ref) => {
+  ({ onClick, onSubmit, onChange, placehorder, btnText, image, name }, ref) => {
     return (
       <>
         <div className={styles['modal-layer']} onClick={onClick}></div>
@@ -20,8 +20,8 @@ export const ModalWrapper = forwardRef(
 
             <div className={styles['modal-receiver']}>
               <span className={styles['modal-to']}>To.</span>
-              <span className={styles['modal-profile']}></span>
-              아초는 고양이
+              <img src={image} className={styles['modal-profile']} alt=""></img>
+              {name}
             </div>
             <QuestionForm
               ref={ref}

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
@@ -43,17 +43,10 @@
   line-height: 30px;
 }
 
-.modal-icon {
-  display: inline-block;
-  width: 28px;
-  height: 28px;
-  background-image: url('/src/assets/icon/ic-messages.svg');
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
-}
-
 .modal-exit-btn {
+  position: absolute;
+  top: 41px;
+  right: 40px;
   background-color: transparent;
   width: 28px;
   height: 28px;
@@ -65,6 +58,7 @@
 
 .blind {
   position: absolute;
+  top: 0;
   width: 1px;
   height: 1px;
   margin: -1px;

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
@@ -80,6 +80,7 @@
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
+  border-radius: 999px;
 }
 
 .modal-receiver {

--- a/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
+++ b/src/components/QuestionModal/ModalWrapper/ModalWrapper.module.css
@@ -63,6 +63,16 @@
   background-size: cover;
 }
 
+.blind {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+}
+
 .modal-to {
   font-size: 1.125rem;
   line-height: 24px;

--- a/src/pages/FeedPage/FeedPage.js
+++ b/src/pages/FeedPage/FeedPage.js
@@ -33,6 +33,19 @@ export function FeedPage() {
 
   const { subjectId } = useParams();
 
+  // 모달 열렸을때 body에 overflow : hidden 스타일 지정
+  useEffect(() => {
+    if (modalOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [modalOpen]);
+
   //useLocation hook
   const location = useLocation();
   const { imageSource, name } = location.state || {};

--- a/src/pages/FeedPage/FeedPage.js
+++ b/src/pages/FeedPage/FeedPage.js
@@ -160,6 +160,8 @@ export function FeedPage() {
           onChange={handleChangeContent}
           placehorder="질문을 입력해주세요"
           btnText="질문 보내기"
+          name={name}
+          image={imageSource}
         />
       )}
       {toast && <Toast setToast={setToast} text="질문이 등록되었습니다" />}

--- a/src/pages/FeedPage/FeedPage.js
+++ b/src/pages/FeedPage/FeedPage.js
@@ -109,9 +109,8 @@ export function FeedPage() {
 
   return (
     <>
-      {' '}
       <Header userImg={imageSource} userName={name} />
-      <div className={styles.feed}>
+      <main className={styles.feed}>
         <div className="wrap-inner2">
           <div className={styles['feed-wrap']}>
             <p className={styles['total-count']}>
@@ -134,7 +133,7 @@ export function FeedPage() {
             )}
           </div>
         </div>
-      </div>
+      </main>
       <span className={styles['btn-link']}>
         <button type="button" onClick={handleClickModal}>
           질문 작성하기


### PR DESCRIPTION
## 개요

- 모달창 업데이트 
-


## 주요 변경사항

- 배경 페이지 스크롤 방지 추가했습니다.
- 닫기 버튼 접근성 개선 : 블라인드 텍스트 추가, 마크업 위치 변경
- 모달창에서 수신인 프로필이미지, 이름 노출 
- 피드페이지 최상단 태그 div → main 변경

## 스크린샷
![image](https://github.com/user-attachments/assets/5b45524d-125e-452c-a373-e4a39a02b37d)


## 기타 이슈

- 
- 
-

[참고]
resolve: #61 
이슈 넘버를 내용에 입력하면 해당 PR merge 시 연결된 이슈가 자동으로 close됩니다. 
