### PR TITLE
5-1 '맨 위로 이동' 버튼 위치 수정

### DIFF
--- a/src/components/ScrollTop/ScrollTop.module.css
+++ b/src/components/ScrollTop/ScrollTop.module.css
@@ -1,10 +1,9 @@
 .scroll-top {
   position: fixed;
-  right: 50%;
-  bottom: 24px;
+  right: 25px;
+  bottom: calc(78px + 8px);
   display: inline-block;
-  display: flex;
-  border: 1px solid var(--brown-30);
+  border: 1px solid var(--brown-40);
   z-index: 2;
   background-color: var(--brown-10);
   width: 50px;

--- a/src/pages/AnswerPage.js
+++ b/src/pages/AnswerPage.js
@@ -136,15 +136,15 @@ export function AnswerPage() {
             )}
           </div>
         </div>
-        {toTop && (
-          <ScrollTop onClick={handleClickTop}>
-            <Top fill="#542f1a" width="36" height="36" />
-          </ScrollTop>
-        )}
       </main>
       <span className={styles['to-list-btn']}>
         <AnswerLinkButton btnLink={'/list'}>질문하러 가기</AnswerLinkButton>
       </span>
+      {toTop && (
+        <ScrollTop onClick={handleClickTop}>
+          <Top fill="#542f1a" width="36" height="36" />
+        </ScrollTop>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 개요
-  '맨 위로 이동' 버튼 위치 수정
-


## 주요 변경사항
- 마크업 수정 (제일 밑으로 이동)
- 버튼 위치 우측으로 변경

## 스크린샷
![image](https://github.com/user-attachments/assets/1fe167cc-7686-42de-bd19-b1fa2a818438)


## 기타 이슈


[참고]
resolve:#
이슈 넘버를 내용에 입력하면 해당 PR merge 시 연결된 이슈가 자동으로 close됩니다. 
